### PR TITLE
Add DirectOut Prodigy series chassis

### DIFF
--- a/device-types/DirectOut/Prodigy.MC.yaml
+++ b/device-types/DirectOut/Prodigy.MC.yaml
@@ -1,0 +1,51 @@
+---
+manufacturer: DirectOut
+model: PRODIGY.MC
+slug: directout-prodigy-mc
+u_height: 2.0
+is_full_depth: true
+airflow: left-to-right
+weight: 10
+weight_unit: kg
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c14
+  - name: PSU 2
+    type: iec-60320-c14
+interfaces:
+  - name: MGMT
+    type: 1000base-t
+    mgmt_only: true
+rear-ports:
+  - name: GPIO
+    type: other
+    positions: 1
+    description: 9 pin D-sub
+  - name: WordClock 1 In
+    type: bnc
+  - name: WordClock 1 out
+    type: bnc
+  - name: WordClock 2 / Video In
+    type: bnc
+  - name: WordClock 2 / Video out
+    type: bnc
+module-bays:
+  - name: Audio network slot
+  - name: MADI 1
+  - name: MADI 2
+  - name: Slot 1
+    position: '1'
+  - name: Slot 2
+    position: '2'
+  - name: Slot 3
+    position: '3'
+  - name: Slot 4
+    position: '4'
+  - name: Slot 5
+    position: '5'
+  - name: Slot 6
+    position: '6'
+  - name: Slot 7
+    position: '7'
+  - name: Slot 8
+    position: '8'

--- a/device-types/DirectOut/Prodigy.MP.yaml
+++ b/device-types/DirectOut/Prodigy.MP.yaml
@@ -1,0 +1,56 @@
+---
+manufacturer: DirectOut
+model: PRODIGY.MP
+slug: directout-prodigy-mp
+u_height: 2.0
+is_full_depth: true
+airflow: left-to-right
+weight: 10
+weight_unit: kg
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c14
+  - name: PSU 2
+    type: iec-60320-c14
+interfaces:
+  - name: MANAGEMENT 1
+    type: 1000base-t
+    mgmt_only: true
+  - name: MANAGEMENT 2
+    type: 1000base-t
+    mgmt_only: true
+  - name: MANAGEMENT 3
+    type: 1000base-x-sfp
+    mgmt_only: true
+rear-ports:
+  - name: GPIO
+    type: other
+    positions: 1
+    description: 9 pin D-sub
+  - name: WordClock 1 In
+    type: bnc
+  - name: WordClock 1 out
+    type: bnc
+  - name: WordClock 2 / Video In
+    type: bnc
+  - name: WordClock 2 / Video out
+    type: bnc
+  - name: MIDI in
+    type: other
+    description: DIN
+  - name: MIDI out
+    type: other
+    description: DIN
+module-bays:
+  - name: MADI 1
+  - name: MADI 2
+  - name: Audio network 1
+  - name: Audio network 2
+  - name: Slot 1
+    position: '1'
+  - name: Slot 2
+    position: '2'
+  - name: Slot 3
+    position: '3'
+  - name: Slot 4
+    position: '4'

--- a/device-types/DirectOut/Prodigy.MX.yaml
+++ b/device-types/DirectOut/Prodigy.MX.yaml
@@ -1,0 +1,45 @@
+---
+manufacturer: DirectOut
+model: PRODIGY.MX
+slug: directout-prodigy-mx
+u_height: 2.0
+is_full_depth: true
+airflow: left-to-right
+weight: 10
+weight_unit: kg
+power-ports:
+  - name: PSU 1
+    type: iec-60320-c14
+  - name: PSU 2
+    type: iec-60320-c14
+interfaces:
+  - name: MANAGEMENT 1
+    type: 1000base-t
+    mgmt_only: true
+  - name: MANAGEMENT 2
+    type: 1000base-t
+    mgmt_only: true
+  - name: MANAGEMENT 3
+    type: 1000base-x-sfp
+    mgmt_only: true
+rear-ports:
+  - name: GPIO
+    type: other
+    positions: 1
+    description: 9 pin D-sub
+  - name: WordClock / Video In
+    type: bnc
+  - name: WordClock / Video out
+    type: bnc
+  - name: WordClock out 1-6
+    type: other
+    description: 9 pin D-sub
+module-bays:
+  - name: MADI 1
+  - name: MADI 2
+  - name: Audio network 1
+  - name: Audio network 2
+  - name: Audio network 3
+  - name: Audio network 4
+  - name: Audio network 5
+  - name: Audio network 6


### PR DESCRIPTION
Based on:

https://www.directout.eu/wp-content/uploads/2021/10/2he-prodigy-mc-03.jpg
https://www.directout.eu/wp-content/uploads/2021/10/2he-prodigy-mp-03.jpg
https://www.directout.eu/wp-content/uploads/2023/08/2he-prodigy-mx-03-mixed_broadcast.jpg