### PR TITLE
Appear naming

### DIFF
--- a/device-types/Appear/X10.yaml
+++ b/device-types/Appear/X10.yaml
@@ -1,7 +1,7 @@
 ---
-manufacturer: AppearTV
+manufacturer: Appear
 model: X10
-slug: appeartv-x10
+slug: appear-x10
 u_height: 1.0
 is_full_depth: true
 subdevice_role: parent

--- a/device-types/Appear/X20.yaml
+++ b/device-types/Appear/X20.yaml
@@ -1,7 +1,7 @@
 ---
-manufacturer: AppearTV
+manufacturer: Appear
 model: X20
-slug: appeartv-x20
+slug: appear-x20
 u_height: 2.0
 is_full_depth: true
 subdevice_role: parent

--- a/module-types/Appear/ECx110.yaml
+++ b/module-types/Appear/ECx110.yaml
@@ -8,34 +8,34 @@ rear-ports:
     positions: 8
 front-ports:
   - name: 1A
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 1
   - name: 1B
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 2
   - name: 1C
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 3
   - name: 1D
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 4
   - name: 2A
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 5
   - name: 2B
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 6
   - name: 2C
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 7
   - name: 2D
-    type: BNC
+    type: bnc
     rear_port: 'Backplane interconnect'
     rear_port_position: 8

--- a/module-types/Appear/ECx110.yaml
+++ b/module-types/Appear/ECx110.yaml
@@ -1,0 +1,41 @@
+---
+manufacturer: Appear
+model: ECx110
+description: Multipurpose IO-modul with 8 micro-BNC connectors. Could be inputs or outputs, depending on loaded software.
+rear-ports:
+  - name: Backplane interconnect
+    type: other
+    positions: 8
+front-ports:
+  - name: 1A
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 1
+  - name: 1B
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 2
+  - name: 1C
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 3
+  - name: 1D
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 4
+  - name: 2A
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 5
+  - name: 2B
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 6
+  - name: 2C
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 7
+  - name: 2D
+    type: BNC
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 8

--- a/module-types/Appear/IPx110.yaml
+++ b/module-types/Appear/IPx110.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Appear
+model: IPx110
+description: Module for receiving and transmitting compressed streams over IP in SRT, Zixi or MPEG-TS (depending on licence).
+interfaces:
+  - name: 'D1'
+    type: 10gbase-x-sfpp
+  - name: 'D2'
+    type: 10gbase-x-sfpp

--- a/module-types/Appear/IPx210.yaml
+++ b/module-types/Appear/IPx210.yaml
@@ -1,6 +1,6 @@
 ---
 manufacturer: Appear
-model: IPx110
+model: IPx210
 description: Module for receiving and transmitting streams over IP in SMPTE2110-formats.
 interfaces:
   - name: 'D1'

--- a/module-types/Appear/IPx210.yaml
+++ b/module-types/Appear/IPx210.yaml
@@ -1,0 +1,9 @@
+---
+manufacturer: Appear
+model: IPx110
+description: Module for receiving and transmitting streams over IP in SMPTE2110-formats.
+interfaces:
+  - name: 'D1'
+    type: 25gbase-x-sfp28
+  - name: 'D2'
+    type: 25gbase-x-sfp28

--- a/module-types/Appear/SWx210.yaml
+++ b/module-types/Appear/SWx210.yaml
@@ -1,0 +1,28 @@
+---
+manufacturer: Appear
+model: SWx210
+description: Switch-module for control, genlock and MPEG-TS traffic in/out
+rear-ports:
+  - name: Backplane interconnect
+    type: other
+    positions: 1
+front-ports:
+  - name: Genlock
+    type: bnc
+    rear_port: 'Backplane interconnect'
+    rear_port_position: 1
+interfaces:
+  - name: 'CTRL'
+    type: 1000base-t
+  - name: 'D1-RJ45'
+    type: 1000base-t
+  - name: 'D1-SFP'
+    type: 10gbase-x-sfpp
+  - name: 'D2-RJ45'
+    type: 1000base-t
+  - name: 'D2-SFP'
+    type: 10gbase-x-sfpp
+  - name: 'D3'
+    type: 1000base-t  
+  - name: 'D4'
+    type: 1000base-t


### PR DESCRIPTION
I don't know where the Appear"TV" name came from, but nowhere can I find that name in documentation. So we should change it as well.